### PR TITLE
Create a basic ArchwayClient

### DIFF
--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-yarn install --immutable --immutable-cache --check-cache
+yarn install

--- a/packages/arch3-core/package.json
+++ b/packages/arch3-core/package.json
@@ -47,7 +47,8 @@
     "lint:sarif": "yarn lint --format @microsoft/eslint-formatter-sarif --output-file eslint-results.sarif"
   },
   "dependencies": {
-    "@cosmjs/cosmwasm-stargate": "^0.28.10"
+    "@cosmjs/cosmwasm-stargate": "^0.28.10",
+    "@cosmjs/tendermint-rpc": "^0.28.10"
   },
   "devDependencies": {
     "@microsoft/eslint-formatter-sarif": "^3.0",

--- a/packages/arch3-core/src/archwayclient.spec.ts
+++ b/packages/arch3-core/src/archwayclient.spec.ts
@@ -1,0 +1,11 @@
+describe('archwayClient', () => {
+  describe('metadata', () => {
+    describe('set', () => {
+      it.todo('can write a contract metadata');
+    });
+
+    describe('get', () => {
+      it.todo('can read a contract metadata');
+    });
+  });
+});

--- a/packages/arch3-core/src/archwayclient.ts
+++ b/packages/arch3-core/src/archwayclient.ts
@@ -1,0 +1,8 @@
+import { CosmWasmClient } from '@cosmjs/cosmwasm-stargate';
+import { Tendermint34Client } from '@cosmjs/tendermint-rpc';
+
+export class ArchwayClient extends CosmWasmClient {
+  protected constructor(tmClient: Tendermint34Client | undefined) {
+    super(tmClient);
+  }
+}

--- a/packages/arch3-core/src/index.test.ts
+++ b/packages/arch3-core/src/index.test.ts
@@ -1,7 +1,0 @@
-import main from './index';
-
-describe('arch3-core', () => {
-  it('says hello', () => {
-    expect(main()).toBe('Hello from arch3.js');
-  });
-});

--- a/packages/arch3-core/src/index.ts
+++ b/packages/arch3-core/src/index.ts
@@ -1,3 +1,2 @@
-export default function main(): string {
-  return 'Hello from arch3.js';
-}
+export { ArchwayClient } from './archwayclient';
+export * from '@cosmjs/cosmwasm-stargate';

--- a/yarn.lock
+++ b/yarn.lock
@@ -20,6 +20,7 @@ __metadata:
   resolution: "@archwayhq/arch3-core@workspace:packages/arch3-core"
   dependencies:
     "@cosmjs/cosmwasm-stargate": ^0.28.10
+    "@cosmjs/tendermint-rpc": ^0.28.10
     "@microsoft/eslint-formatter-sarif": ^3.0
     "@types/jest": ^28.1
     "@types/node": ^18.0
@@ -554,7 +555,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@cosmjs/tendermint-rpc@npm:0.28.10":
+"@cosmjs/tendermint-rpc@npm:0.28.10, @cosmjs/tendermint-rpc@npm:^0.28.10":
   version: 0.28.10
   resolution: "@cosmjs/tendermint-rpc@npm:0.28.10"
   dependencies:


### PR DESCRIPTION
The `ArchwayClient` is a simple extension of the `CosmWasmClient`. In this basic implementation, it works as a drop-in replacement for the later.

Related to #8