### PR TITLE
build(arch3-proto): add module exports to package

### DIFF
--- a/packages/arch3-proto/package.json
+++ b/packages/arch3-proto/package.json
@@ -37,6 +37,10 @@
   ],
   "main": "build/index.js",
   "types": "build/index.d.ts",
+  "exports": {
+    ".": "./build/index.js",
+    "./*": "./build/*.js"
+  },
   "scripts": {
     "prepack": "yarn run build",
     "clean": "rimraf ./build",


### PR DESCRIPTION
This feature allows importing the package modules using paths without the `/build` folder prefix.

More info: https://nodejs.org/api/packages.html#package-entry-points