### PR TITLE
refactor(arch3-core): move the rewards queries to a facade

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -160,6 +160,10 @@ module.exports = {
         format: ['strictCamelCase'],
         leadingUnderscore: 'allow',
       },
+      {
+        selector: 'interface',
+        format: ['PascalCase'],
+      },
     ],
     '@typescript-eslint/no-dynamic-delete': 'warn',
     '@typescript-eslint/no-empty-function': 'off',

--- a/packages/arch3-core/src/archwayclient.ts
+++ b/packages/arch3-core/src/archwayclient.ts
@@ -43,7 +43,7 @@ export class ArchwayClient extends CosmWasmClient implements IArchwayQueryClient
    * @param tmClient - A Tendermint client for a given endpoint.
    * @returns An {@link ArchwayClient} connected to the endpoint.
    */
-  // eslint-disable-next-line @typescript-eslint/require-await
+  /* eslint-disable-next-line @typescript-eslint/require-await */
   public static override async create(tmClient: TendermintClient): Promise<ArchwayClient> {
     return new ArchwayClient(tmClient);
   }

--- a/packages/arch3-core/src/archwayclient.ts
+++ b/packages/arch3-core/src/archwayclient.ts
@@ -1,349 +1,78 @@
-import { CosmWasmClient, HttpEndpoint, setupWasmExtension, WasmExtension } from '@cosmjs/cosmwasm-stargate';
+import { CosmWasmClient, HttpEndpoint } from '@cosmjs/cosmwasm-stargate';
+import { Tendermint34Client, TendermintClient } from '@cosmjs/tendermint-rpc';
+
+import { IArchwayQueryClient, createArchwayQueryClient } from './queryclient';
 import {
-  AuthExtension,
-  BankExtension,
-  Coin,
-  QueryClient,
-  setupAuthExtension,
-  setupBankExtension,
-  setupTxExtension,
-  TxExtension
-} from '@cosmjs/stargate';
-import { fromSeconds, Tendermint34Client, TendermintClient, toRfc3339WithNanoseconds } from '@cosmjs/tendermint-rpc';
-
-import { RewardsExtension, setupRewardsExtension } from './modules';
-
-/**
- * Defines the contract rewards distribution options for a particular contract.
- *
- * @see {@link ArchwayClient.getContractMetadata}
- */
-export interface ContractMetadata {
-  /** Contract address. */
-  readonly contractAddress: string;
-  /**
-   * Owner address who can modify contract the metadata.
-   * That could be the contract admin or the contract itself.
-   * If the owner address is set to a contract address,
-   * the contract can modify the metadata on its own using the WASM bindings.
-   */
-  readonly ownerAddress: string;
-  /**
-   * Address to distribute rewards to. If not set, rewards are not distributed for this contract.
-   */
-  readonly rewardsAddress: string;
-}
-
-/**
- * Defines the contract premium fee for a particular contract.
- *
- * @see {@link ArchwayClient.getContractPremium}
- */
-export interface ContractPremium {
-  /** Contract address. */
-  readonly contractAddress: string;
-  /** Contract premium fee set by the contract metadata owner. */
-  readonly flatFee?: Coin;
-}
-
-/**
- * Contains the transaction fees estimation for a given gas limit,
- * including the contract premium if a contract address is provided.
- *
- * @see {@link ArchwayClient.getEstimateTxFees}
- */
-export interface EstimateTxFees {
-  /** Maximum amount of gas to be used in this transaction. */
-  readonly gasLimit: number;
-  /** Minimum transaction fee per gas unit. */
-  readonly gasUnitPrice?: Coin;
-  /** Contract address used to query for premium fees. */
-  readonly contractAddress?: string;
-  /** Estimated transaction fee for a given gas limit and contract premium. */
-  readonly estimatedFee: Coin[];
-}
-
-/**
- * Outstanding rewards available for a rewards address.
- *
- * @see {@link ArchwayClient.getBlockRewardsTracking}
- */
-export interface OutstandingRewards {
-  /** Address to which the rewards are deposited. */
-  readonly rewardsAddress: string;
-  /** Total rewards credited to the rewards address. */
-  readonly totalRewards: Coin[];
-  /** Total number of RewardsRecord objects stored for the rewards address. */
-  readonly recordsNum: number;
-}
-
-/**
- * Contains all rewards ready for withdrawal and treasury funds.
- *
- * @see {@link ArchwayClient.getRewardsPool}
- */
-export interface RewardsPool {
-  /** Tokens ready for withdrawal. */
-  readonly undistributedFunds: Coin[];
-  /**
-   * Treasury tokens available. Treasury tokens are collected on a block basis.
-   * Those tokens are the unused block rewards.
-   */
-  readonly treasuryFunds: Coin[];
-}
-
-/**
- * Defines rewards that are pending withdraw.
- * This record is being created by the x/rewards EndBlocker and pruned after the rewards are distributed.
- *
- * @see {@link ArchwayClient.getAllRewardsRecords}
- */
-export interface RewardsRecord {
-  /** Unique ID of the record. */
-  readonly id: number;
-  /** Address to distribute rewards to. */
-  readonly rewardsAddress: string;
-  /** Rewards available for withdraw. */
-  readonly rewards: Coin[];
-  /** Block height at which the rewards were calculated. */
-  readonly calculatedHeight: number;
-  /** Block time at which the rewards were calculated. */
-  readonly calculatedTime?: string;
-}
-
-/**
- * Defines rewards distribution data for a particular block.
- *
- * @see {@link ArchwayClient.getBlockRewardsTracking}
- */
-export interface BlockRewards {
-  /** Current the block height. */
-  readonly height: number;
-  /** Inflation rewards distributed in the block. */
-  readonly inflationRewards?: Coin;
-  /** Maximum gas for the block that is used to distribute inflation rewards (consensus parameter). */
-  readonly maxGas: number;
-}
-
-/**
- * Defines rewards distribution data related to a transaction.
- *
- * @see {@link ArchwayClient.getBlockRewardsTracking}
- */
-export interface TxRewards {
-  /** Tracking transaction ID. */
-  readonly txId: number;
-  /** Block height when the rewards were calculated. */
-  readonly height: number;
-  /** Amount of fee rewards to be distributed. */
-  readonly feeRewards: Coin[];
-}
-
-/**
- * Rewards tracking information for a particular block.
- *
- * @see {@link ArchwayClient.getBlockRewardsTracking}
- */
-export interface BlockTracking {
-  /** Inflation rewards for the block. */
-  readonly inflationRewards?: BlockRewards;
-  /** Transaction rewards for the block. */
-  readonly txRewards: TxRewards[];
-}
-
-type ArchwayQueryClient = QueryClient & AuthExtension & BankExtension & TxExtension & WasmExtension & RewardsExtension;
+  BlockTracking,
+  ContractMetadata,
+  ContractPremium,
+  EstimateTxFees,
+  OutstandingRewards,
+  RewardsPool,
+  RewardsRecord
+} from './types';
 
 /**
  * Extension to the {@link CosmWasmClient } with queries for Archway's modules.
  */
-export class ArchwayClient extends CosmWasmClient {
-  private readonly archwayQueryClient: ArchwayQueryClient | undefined;
-
-  /**
-   * @param endpoint - String URL of the RPC endpoint to connect or an `HttpEndpoint` object.
-   * @returns An `ArchwayClient` connected to the endpoint.
-   */
-  public static override async connect(endpoint: string | HttpEndpoint): Promise<ArchwayClient> {
-    const tmClient = await Tendermint34Client.connect(endpoint);
-    return new ArchwayClient(tmClient);
-  }
+export class ArchwayClient extends CosmWasmClient implements IArchwayQueryClient {
+  private readonly archwayQueryClient: IArchwayQueryClient;
 
   protected constructor(tmClient: TendermintClient | undefined) {
     super(tmClient);
-    if (tmClient) {
-      this.archwayQueryClient = QueryClient.withExtensions(
-        tmClient,
-        setupAuthExtension,
-        setupBankExtension,
-        setupWasmExtension,
-        setupRewardsExtension,
-        setupTxExtension,
-      );
-    }
-  }
-
-  protected getArchwayQueryClient(): ArchwayQueryClient | undefined {
-    return this.archwayQueryClient;
-  }
-
-  protected forceGetArchwayQueryClient(): ArchwayQueryClient {
-    if (!this.archwayQueryClient) {
-      throw new Error('Query client not available. You cannot use online functionality in offline mode.');
-    }
-    return this.archwayQueryClient;
+    this.archwayQueryClient = createArchwayQueryClient(tmClient);
   }
 
   /**
-   * Queries the rewards tracking data for the current block height.
+   * Creates an instance by connecting to the given Tendermint RPC endpoint.
    *
-   * @returns The current block rewards tracking information.
+   * @param endpoint - String URL of the RPC endpoint to connect or an `HttpEndpoint` object.
+   * @returns An {@link ArchwayClient} connected to the endpoint.
+   *
+   * @see Use {@link ArchwayClient.create} if you need Tendermint 0.37 support.
    */
+  public static override async connect(endpoint: string | HttpEndpoint): Promise<ArchwayClient> {
+    const tmClient = await Tendermint34Client.connect(endpoint);
+    return ArchwayClient.create(tmClient);
+  }
+
+  /**
+   * Creates an instance from a manually created Tendermint client.
+   * Use this to use `Tendermint37Client instead of {@link Tendermint34Client}.
+   *
+   * @param tmClient - A Tendermint client for a given endpoint.
+   * @returns An {@link ArchwayClient} connected to the endpoint.
+   */
+  // eslint-disable-next-line @typescript-eslint/require-await
+  public static override async create(tmClient: TendermintClient): Promise<ArchwayClient> {
+    return new ArchwayClient(tmClient);
+  }
+
   public async getBlockRewardsTracking(): Promise<BlockTracking> {
-    const client = this.forceGetArchwayQueryClient();
-    const {
-      block: { txRewards: txRewardsResponse, inflationRewards }
-    } = await client.rewards.blockRewardsTracking();
-
-    const txRewards = txRewardsResponse.map(txReward => { return {
-      txId: txReward.txId.toNumber(),
-      height: txReward.height.toNumber(),
-      feeRewards: txReward.feeRewards,
-    }; });
-
-    return {
-      inflationRewards: {
-        height: inflationRewards.height.toNumber(),
-        inflationRewards: inflationRewards.inflationRewards,
-        maxGas: inflationRewards.maxGas.toNumber(),
-      },
-      txRewards,
-    };
+    return await this.archwayQueryClient.getBlockRewardsTracking();
   }
 
-  /**
-   * Queries a contract metadata for information on the rewards destination.
-   *
-   * @param contractAddress - Contract address to query the metadata for.
-   * @returns The contract metadata.
-   */
   public async getContractMetadata(contractAddress: string): Promise<ContractMetadata | undefined> {
-    const client = this.forceGetArchwayQueryClient();
-    const {
-      metadata: { ownerAddress, rewardsAddress }
-    } = await client.rewards.contractMetadata(contractAddress);
-
-    return {
-      contractAddress,
-      ownerAddress,
-      rewardsAddress
-    };
+    return await this.archwayQueryClient.getContractMetadata(contractAddress);
   }
 
-  /**
-   * Queries the premium fee for a contract.
-   *
-   * @param contractAddress - Contract address to query the premium for.
-   * @returns The contract premium data.
-   */
   public async getContractPremium(contractAddress: string): Promise<ContractPremium> {
-    const client = this.forceGetArchwayQueryClient();
-    const { flatFeeAmount } = await client.rewards.flatFee(contractAddress);
-
-    return {
-      contractAddress,
-      flatFee: flatFeeAmount,
-    };
+    return await this.archwayQueryClient.getContractPremium(contractAddress);
   }
 
-  /**
-   * Queries the transaction fees estimation for a given gas limit.
-   * Optionally takes in contract address to include the flat fees in the estimate.
-   *
-   * @param gasLimit - Gas limit to estimate the fees for.
-   * @param contractAddress - Contract address to include the flat fees in the estimate.
-   * @returns The estimated transaction fees for the lastest block.
-   */
   public async getEstimateTxFees(gasLimit: number, contractAddress?: string): Promise<EstimateTxFees> {
-    const client = this.forceGetArchwayQueryClient();
-    const { estimatedFee, gasUnitPrice } = await client.rewards.estimateTxFees(gasLimit, contractAddress || '');
-
-    return {
-      gasLimit,
-      contractAddress,
-      estimatedFee,
-      gasUnitPrice,
-    };
+    return await this.archwayQueryClient.getEstimateTxFees(gasLimit, contractAddress);
   }
 
-  /**
-   * Queries the unclaimed rewards available for a given address.
-   *
-   * @param rewardsAddress - address set in a contract's metadata to receive rewards
-   * @returns The outstanding rewards for the given address.
-   */
   public async getOutstandingRewards(rewardsAddress: string): Promise<OutstandingRewards> {
-    const client = this.forceGetArchwayQueryClient();
-    const { totalRewards, recordsNum } = await client.rewards.outstandingRewards(rewardsAddress);
-
-    return {
-      rewardsAddress,
-      totalRewards,
-      recordsNum: recordsNum.toNumber(),
-    };
+    return await this.archwayQueryClient.getOutstandingRewards(rewardsAddress);
   }
 
-  /**
-   * Queries the pool with undistributed rewards and the treasury pool funds.
-   *
-   * @returns The rewards pool information.
-   */
   public async getRewardsPool(): Promise<RewardsPool> {
-    const client = this.forceGetArchwayQueryClient();
-    const { undistributedFunds, treasuryFunds } = await client.rewards.rewardsPool();
-
-    return {
-      undistributedFunds,
-      treasuryFunds
-    };
+    return await this.archwayQueryClient.getRewardsPool();
   }
 
-  /**
-   * Queries all available rewards stored for a given address set in a contract's metadata.
-   *
-   * @param rewardsAddress - Address set in a contract's metadata to receive rewards.
-   * @returns All rewards records for the given address.
-   *
-   * @see {@link ArchwayClient.getContractMetadata}
-   */
   public async getAllRewardsRecords(rewardsAddress: string): Promise<readonly RewardsRecord[]> {
-    const client = this.forceGetArchwayQueryClient();
-
-    const allRewardsRecords = new Array<RewardsRecord>();
-    let startAtKey: Uint8Array | undefined = undefined;
-
-    do {
-      /* eslint no-await-in-loop: "off" */
-      const { records, pagination } = await client.rewards.rewardsRecords(rewardsAddress, startAtKey);
-
-      const rewardsRecords = records.map(record => {
-        const calculatedTime = fromSeconds(
-          record.calculatedTime.seconds.toNumber(),
-          record.calculatedTime.nanos
-        );
-        return {
-          id: record.id.toNumber(),
-          rewardsAddress: record.rewardsAddress,
-          calculatedHeight: record.calculatedHeight.toNumber(),
-          calculatedTime: toRfc3339WithNanoseconds(calculatedTime),
-          rewards: record.rewards,
-        };
-      });
-
-      allRewardsRecords.push(...rewardsRecords);
-
-      startAtKey = pagination?.nextKey;
-    } while (startAtKey?.length !== 0);
-
-    return allRewardsRecords;
+    return await this.archwayQueryClient.getAllRewardsRecords(rewardsAddress);
   }
 }

--- a/packages/arch3-core/src/index.ts
+++ b/packages/arch3-core/src/index.ts
@@ -5,3 +5,5 @@ export { ArchwayClient } from './archwayclient';
 export { SigningArchwayClient } from './signingarchwayclient';
 
 export * from './modules';
+export * from './types';
+export * from './queryclient';

--- a/packages/arch3-core/src/queryclient.ts
+++ b/packages/arch3-core/src/queryclient.ts
@@ -1,0 +1,236 @@
+import { setupWasmExtension, WasmExtension } from '@cosmjs/cosmwasm-stargate';
+import {
+  AuthExtension,
+  BankExtension,
+  QueryClient,
+  setupAuthExtension,
+  setupBankExtension,
+  setupTxExtension,
+  TxExtension
+} from '@cosmjs/stargate';
+import { fromSeconds, TendermintClient, toRfc3339WithNanoseconds } from '@cosmjs/tendermint-rpc';
+
+import { RewardsExtension, setupRewardsExtension } from './modules';
+import {
+  BlockTracking,
+  ContractMetadata,
+  ContractPremium,
+  EstimateTxFees,
+  OutstandingRewards,
+  RewardsPool,
+  RewardsRecord
+} from './types';
+
+type ExtendedQueryClient = QueryClient & AuthExtension & BankExtension & TxExtension & WasmExtension & RewardsExtension;
+
+/**
+ * Interface for querying the Archway modules.
+ */
+export interface IArchwayQueryClient {
+  /**
+   * Queries the rewards tracking data for the current block height.
+   *
+   * @returns The current block rewards tracking information.
+   */
+  getBlockRewardsTracking(): Promise<BlockTracking>;
+
+  /**
+   * Queries a contract metadata for information on the rewards destination.
+   *
+   * @param contractAddress - Contract address to query the metadata for.
+   * @returns The contract metadata.
+   */
+  getContractMetadata(contractAddress: string): Promise<ContractMetadata | undefined>;
+
+  /**
+   * Queries the premium fee for a contract.
+   *
+   * @param contractAddress - Contract address to query the premium for.
+   * @returns The contract premium data.
+   */
+  getContractPremium(contractAddress: string): Promise<ContractPremium>;
+
+  /**
+   * Queries the transaction fees estimation for a given gas limit.
+   * Optionally takes in contract address to include the flat fees in the estimate.
+   *
+   * @param gasLimit - Gas limit to estimate the fees for.
+   * @param contractAddress - Contract address to include the flat fees in the estimate.
+   * @returns The estimated transaction fees for the lastest block.
+   */
+  getEstimateTxFees(gasLimit: number, contractAddress?: string): Promise<EstimateTxFees>;
+
+  /**
+   * Queries the unclaimed rewards available for a given address.
+   *
+   * @param rewardsAddress - address set in a contract's metadata to receive rewards
+   * @returns The outstanding rewards for the given address.
+   */
+  getOutstandingRewards(rewardsAddress: string): Promise<OutstandingRewards>;
+
+  /**
+   * Queries the pool with undistributed rewards and the treasury pool funds.
+   *
+   * @returns The rewards pool information.
+   */
+  getRewardsPool(): Promise<RewardsPool>;
+
+  /**
+   * Queries all available rewards stored for a given address set in a contract's metadata.
+   *
+   * @param rewardsAddress - Address set in a contract's metadata to receive rewards.
+   * @returns All rewards records for the given address.
+   *
+   * @see {@link ArchwayClient.getContractMetadata}
+   */
+  getAllRewardsRecords(rewardsAddress: string): Promise<readonly RewardsRecord[]>;
+}
+
+class ArchwayQueryClientImpl implements IArchwayQueryClient {
+  private readonly queryClient: ExtendedQueryClient | undefined;
+
+  public constructor(tmClient: TendermintClient | undefined) {
+    if (tmClient) {
+      this.queryClient = QueryClient.withExtensions(
+        tmClient,
+        setupAuthExtension,
+        setupBankExtension,
+        setupWasmExtension,
+        setupRewardsExtension,
+        setupTxExtension,
+      );
+    }
+  }
+
+  protected getQueryClient(): ExtendedQueryClient | undefined {
+    return this.queryClient;
+  }
+
+  protected forceGetQueryClient(): ExtendedQueryClient {
+    if (!this.queryClient) {
+      throw new Error('Query client not available. You cannot use online functionality in offline mode.');
+    }
+    return this.queryClient;
+  }
+
+  public async getBlockRewardsTracking(): Promise<BlockTracking> {
+    const client = this.forceGetQueryClient();
+    const {
+      block: { txRewards: txRewardsResponse, inflationRewards }
+    } = await client.rewards.blockRewardsTracking();
+
+    const txRewards = txRewardsResponse.map(txReward => { return {
+      txId: txReward.txId.toNumber(),
+      height: txReward.height.toNumber(),
+      feeRewards: txReward.feeRewards,
+    }; });
+
+    return {
+      inflationRewards: {
+        height: inflationRewards.height.toNumber(),
+        inflationRewards: inflationRewards.inflationRewards,
+        maxGas: inflationRewards.maxGas.toNumber(),
+      },
+      txRewards,
+    };
+  }
+
+  public async getContractMetadata(contractAddress: string): Promise<ContractMetadata | undefined> {
+    const client = this.forceGetQueryClient();
+    const {
+      metadata: { ownerAddress, rewardsAddress }
+    } = await client.rewards.contractMetadata(contractAddress);
+
+    return {
+      contractAddress,
+      ownerAddress,
+      rewardsAddress
+    };
+  }
+
+  public async getContractPremium(contractAddress: string): Promise<ContractPremium> {
+    const client = this.forceGetQueryClient();
+    const { flatFeeAmount } = await client.rewards.flatFee(contractAddress);
+
+    return {
+      contractAddress,
+      flatFee: flatFeeAmount,
+    };
+  }
+
+  public async getEstimateTxFees(gasLimit: number, contractAddress?: string): Promise<EstimateTxFees> {
+    const client = this.forceGetQueryClient();
+    const { estimatedFee, gasUnitPrice } = await client.rewards.estimateTxFees(gasLimit, contractAddress || '');
+
+    return {
+      gasLimit,
+      contractAddress,
+      estimatedFee,
+      gasUnitPrice,
+    };
+  }
+
+  public async getOutstandingRewards(rewardsAddress: string): Promise<OutstandingRewards> {
+    const client = this.forceGetQueryClient();
+    const { totalRewards, recordsNum } = await client.rewards.outstandingRewards(rewardsAddress);
+
+    return {
+      rewardsAddress,
+      totalRewards,
+      recordsNum: recordsNum.toNumber(),
+    };
+  }
+
+  public async getRewardsPool(): Promise<RewardsPool> {
+    const client = this.forceGetQueryClient();
+    const { undistributedFunds, treasuryFunds } = await client.rewards.rewardsPool();
+
+    return {
+      undistributedFunds,
+      treasuryFunds
+    };
+  }
+
+  public async getAllRewardsRecords(rewardsAddress: string): Promise<readonly RewardsRecord[]> {
+    const client = this.forceGetQueryClient();
+
+    const allRewardsRecords = new Array<RewardsRecord>();
+    let startAtKey: Uint8Array | undefined = undefined;
+
+    do {
+      /* eslint no-await-in-loop: "off" */
+      const { records, pagination } = await client.rewards.rewardsRecords(rewardsAddress, startAtKey);
+
+      const rewardsRecords = records.map(record => {
+        const calculatedTime = fromSeconds(
+          record.calculatedTime.seconds.toNumber(),
+          record.calculatedTime.nanos
+        );
+        return {
+          id: record.id.toNumber(),
+          rewardsAddress: record.rewardsAddress,
+          calculatedHeight: record.calculatedHeight.toNumber(),
+          calculatedTime: toRfc3339WithNanoseconds(calculatedTime),
+          rewards: record.rewards,
+        };
+      });
+
+      allRewardsRecords.push(...rewardsRecords);
+
+      startAtKey = pagination?.nextKey;
+    } while (startAtKey?.length !== 0);
+
+    return allRewardsRecords;
+  }
+}
+
+/**
+ * Created a facade for querying archway modules using the
+ * {@link QueryClient} extended with the {@link RewardsExtension}.
+ *
+ * @param tmClient - A Tendermint client for a given endpoint.
+ * @returns A new {@link IArchwayQueryClient} implementation.
+ */
+export function createArchwayQueryClient(tmClient: TendermintClient | undefined): IArchwayQueryClient {
+  return new ArchwayQueryClientImpl(tmClient);
+}

--- a/packages/arch3-core/src/signingarchwayclient.ts
+++ b/packages/arch3-core/src/signingarchwayclient.ts
@@ -1,21 +1,39 @@
 import { HttpEndpoint, SigningCosmWasmClient, SigningCosmWasmClientOptions } from '@cosmjs/cosmwasm-stargate';
 import { OfflineSigner } from '@cosmjs/proto-signing';
-import { Tendermint34Client } from '@cosmjs/tendermint-rpc';
+import { Tendermint34Client, TendermintClient } from '@cosmjs/tendermint-rpc';
+
+import { IArchwayQueryClient, createArchwayQueryClient } from './queryclient';
+import {
+  BlockTracking,
+  ContractMetadata,
+  ContractPremium,
+  EstimateTxFees,
+  OutstandingRewards,
+  RewardsPool,
+  RewardsRecord
+} from './types';
 
 /**
  * Extension to the {@link SigningCosmWasmClient }.
  *
  */
-export class SigningArchwayClient extends SigningCosmWasmClient {
-  protected constructor(tmClient: Tendermint34Client | undefined, signer: OfflineSigner, options: SigningCosmWasmClientOptions) {
+export class SigningArchwayClient extends SigningCosmWasmClient implements IArchwayQueryClient {
+  private readonly archwayQueryClient: IArchwayQueryClient;
+
+  protected constructor(tmClient: TendermintClient | undefined, signer: OfflineSigner, options: SigningCosmWasmClientOptions) {
     super(tmClient, signer, options);
+    this.archwayQueryClient = createArchwayQueryClient(tmClient);
   }
 
   /**
+   * Creates an instance by connecting to the given Tendermint RPC endpoint.
+   *
    * @param endpoint - String URL of the RPC endpoint to connect or an `HttpEndpoint` object.
    * @param signer - The transaction signer configuration.
-   * @param options - Options for signing and broadcasting transactions.
-   * @returns A `SigningArchwayClient` connected to the endpoint.
+   * @param options - Options for the signing client.
+   * @returns A {@link SigningArchwayClient} connected to the endpoint.
+   *
+   * @see Use {@link SigningCosmWasmClient.createWithSigner} if you need Tendermint 0.37 support.
    */
   public static override async connectWithSigner(
     endpoint: string | HttpEndpoint,
@@ -23,6 +41,23 @@ export class SigningArchwayClient extends SigningCosmWasmClient {
     options: SigningCosmWasmClientOptions = {},
   ): Promise<SigningArchwayClient> {
     const tmClient = await Tendermint34Client.connect(endpoint);
+    return SigningArchwayClient.createWithSigner(tmClient, signer, options);
+  }
+
+  /**
+   * Creates an instance from a manually created Tendermint client.
+   *
+   * @param tmClient - A Tendermint client for a given endpoint.
+   * @param signer - The transaction signer configuration.
+   * @param options - Options for the signing client.
+   * @returns A {@link SigningArchwayClient} connected to the endpoint.
+   */
+  // eslint-disable-next-line @typescript-eslint/require-await
+  public static override async createWithSigner(
+    tmClient: TendermintClient,
+    signer: OfflineSigner,
+    options: SigningCosmWasmClientOptions = {},
+  ): Promise<SigningArchwayClient> {
     return new SigningArchwayClient(tmClient, signer, options);
   }
 
@@ -37,7 +72,7 @@ export class SigningArchwayClient extends SigningCosmWasmClient {
    *
    * @param signer - the transaction signer configuration.
    * @param options - options for signing and broadcasting transactions.
-   * @returns An offline `SigningArchwayClient`.
+   * @returns An offline {@link SigningArchwayClient}.
    */
   // eslint-disable-next-line @typescript-eslint/require-await
   public static override async offline(
@@ -45,5 +80,33 @@ export class SigningArchwayClient extends SigningCosmWasmClient {
     options: SigningCosmWasmClientOptions = {},
   ): Promise<SigningArchwayClient> {
     return new SigningArchwayClient(undefined, signer, options);
+  }
+
+  public async getBlockRewardsTracking(): Promise<BlockTracking> {
+    return await this.archwayQueryClient.getBlockRewardsTracking();
+  }
+
+  public async getContractMetadata(contractAddress: string): Promise<ContractMetadata | undefined> {
+    return await this.archwayQueryClient.getContractMetadata(contractAddress);
+  }
+
+  public async getContractPremium(contractAddress: string): Promise<ContractPremium> {
+    return await this.archwayQueryClient.getContractPremium(contractAddress);
+  }
+
+  public async getEstimateTxFees(gasLimit: number, contractAddress?: string): Promise<EstimateTxFees> {
+    return await this.archwayQueryClient.getEstimateTxFees(gasLimit, contractAddress);
+  }
+
+  public async getOutstandingRewards(rewardsAddress: string): Promise<OutstandingRewards> {
+    return await this.archwayQueryClient.getOutstandingRewards(rewardsAddress);
+  }
+
+  public async getRewardsPool(): Promise<RewardsPool> {
+    return await this.archwayQueryClient.getRewardsPool();
+  }
+
+  public async getAllRewardsRecords(rewardsAddress: string): Promise<readonly RewardsRecord[]> {
+    return await this.archwayQueryClient.getAllRewardsRecords(rewardsAddress);
   }
 }

--- a/packages/arch3-core/src/signingarchwayclient.ts
+++ b/packages/arch3-core/src/signingarchwayclient.ts
@@ -52,7 +52,7 @@ export class SigningArchwayClient extends SigningCosmWasmClient implements IArch
    * @param options - Options for the signing client.
    * @returns A {@link SigningArchwayClient} connected to the endpoint.
    */
-  // eslint-disable-next-line @typescript-eslint/require-await
+  /* eslint-disable-next-line @typescript-eslint/require-await */
   public static override async createWithSigner(
     tmClient: TendermintClient,
     signer: OfflineSigner,
@@ -74,7 +74,7 @@ export class SigningArchwayClient extends SigningCosmWasmClient implements IArch
    * @param options - options for signing and broadcasting transactions.
    * @returns An offline {@link SigningArchwayClient}.
    */
-  // eslint-disable-next-line @typescript-eslint/require-await
+  /* eslint-disable-next-line @typescript-eslint/require-await */
   public static override async offline(
     signer: OfflineSigner,
     options: SigningCosmWasmClientOptions = {},

--- a/packages/arch3-core/src/types.ts
+++ b/packages/arch3-core/src/types.ts
@@ -1,0 +1,139 @@
+import { Coin } from '@cosmjs/stargate';
+
+/**
+ * Defines the contract rewards distribution options for a particular contract.
+ *
+ * @see {@link ./queryclient!IArchwayQueryClient.getContractMetadata}
+ */
+export interface ContractMetadata {
+  /** Contract address. */
+  readonly contractAddress: string;
+  /**
+   * Owner address who can modify contract the metadata.
+   * That could be the contract admin or the contract itself.
+   * If the owner address is set to a contract address,
+   * the contract can modify the metadata on its own using the WASM bindings.
+   */
+  readonly ownerAddress?: string;
+  /**
+   * Address to distribute rewards to. If not set, rewards are not distributed for this contract.
+   */
+  readonly rewardsAddress?: string;
+}
+
+/**
+ * Defines the contract premium fee for a particular contract.
+ *
+ * @see {@link ./queryclient!IArchwayQueryClient.getContractPremium}
+ */
+export interface ContractPremium {
+  /** Contract address. */
+  readonly contractAddress: string;
+  /** Contract premium fee set by the contract metadata owner. */
+  readonly flatFee?: Coin;
+}
+
+/**
+ * Contains the transaction fees estimation for a given gas limit,
+ * including the contract premium if a contract address is provided.
+ *
+ * @see {@link ./queryclient!IArchwayQueryClient.getEstimateTxFees}
+ */
+export interface EstimateTxFees {
+  /** Maximum amount of gas to be used in this transaction. */
+  readonly gasLimit: number;
+  /** Minimum transaction fee per gas unit. */
+  readonly gasUnitPrice?: Coin;
+  /** Contract address used to query for premium fees. */
+  readonly contractAddress?: string;
+  /** Estimated transaction fee for a given gas limit and contract premium. */
+  readonly estimatedFee: Coin[];
+}
+
+/**
+ * Outstanding rewards available for a rewards address.
+ *
+ * @see {@link ./queryclient!IArchwayQueryClient.getBlockRewardsTracking}
+ */
+export interface OutstandingRewards {
+  /** Address to which the rewards are deposited. */
+  readonly rewardsAddress: string;
+  /** Total rewards credited to the rewards address. */
+  readonly totalRewards: Coin[];
+  /** Total number of RewardsRecord objects stored for the rewards address. */
+  readonly recordsNum: number;
+}
+
+/**
+ * Contains all rewards ready for withdrawal and treasury funds.
+ *
+ * @see {@link ./queryclient!IArchwayQueryClient.getRewardsPool}
+ */
+export interface RewardsPool {
+  /** Tokens ready for withdrawal. */
+  readonly undistributedFunds: Coin[];
+  /**
+   * Treasury tokens available. Treasury tokens are collected on a block basis.
+   * Those tokens are the unused block rewards.
+   */
+  readonly treasuryFunds: Coin[];
+}
+
+/**
+ * Defines rewards that are pending withdraw.
+ * This record is being created by the x/rewards EndBlocker and pruned after the rewards are distributed.
+ *
+ * @see {@link ./queryclient!IArchwayQueryClient.getAllRewardsRecords}
+ */
+export interface RewardsRecord {
+  /** Unique ID of the record. */
+  readonly id: number;
+  /** Address to distribute rewards to. */
+  readonly rewardsAddress: string;
+  /** Rewards available for withdraw. */
+  readonly rewards: Coin[];
+  /** Block height at which the rewards were calculated. */
+  readonly calculatedHeight: number;
+  /** Block time at which the rewards were calculated. */
+  readonly calculatedTime?: string;
+}
+
+/**
+ * Defines rewards distribution data for a particular block.
+ *
+ * @see {@link ./queryclient!IArchwayQueryClient.getBlockRewardsTracking}
+ */
+export interface BlockRewards {
+  /** Current the block height. */
+  readonly height: number;
+  /** Inflation rewards distributed in the block. */
+  readonly inflationRewards?: Coin;
+  /** Maximum gas for the block that is used to distribute inflation rewards (consensus parameter). */
+  readonly maxGas: number;
+}
+
+/**
+ * Defines rewards distribution data related to a transaction.
+ *
+ * @see {@link ./queryclient!IArchwayQueryClient.getBlockRewardsTracking}
+ */
+export interface TxRewards {
+  /** Tracking transaction ID. */
+  readonly txId: number;
+  /** Block height when the rewards were calculated. */
+  readonly height: number;
+  /** Amount of fee rewards to be distributed. */
+  readonly feeRewards: Coin[];
+}
+
+/**
+ * Rewards tracking information for a particular block.
+ *
+ * @see {@link ./queryclient!IArchwayQueryClient.getBlockRewardsTracking}
+ */
+export interface BlockTracking {
+  /** Inflation rewards for the block. */
+  readonly inflationRewards?: BlockRewards;
+  /** Transaction rewards for the block. */
+  readonly txRewards: TxRewards[];
+}


### PR DESCRIPTION
This PR moves the implementation of Archway's modules queries to an external facade so that it can be reused by both the `ArchwayClient` and the `SigningArchwayClient`.