### PR TITLE
test: enable jest transform cache

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "clean:all": "yarn workspaces foreach --parallel --verbose run clean",
     "build": "yarn clean && tsc --build",
     "build:all": "yarn workspaces foreach --topological-dev --parallel --verbose run build",
-    "test": "jest --no-cache",
+    "test": "jest",
     "test:watch": "yarn test --watch",
     "test:all": "yarn workspaces foreach --topological-dev --parallel --verbose run test --passWithNoTests",
     "lint": "eslint ./src --ext .js,.cjs,.ts --no-error-on-unmatched-pattern",

--- a/packages/arch3-core/package.json
+++ b/packages/arch3-core/package.json
@@ -41,7 +41,7 @@
     "prepack": "yarn run build",
     "clean": "rimraf ./build",
     "build": "yarn clean && tsc --build",
-    "test": "DOTENV_CONFIG_PATH=../../.env jest --no-cache",
+    "test": "DOTENV_CONFIG_PATH=../../.env jest",
     "test:watch": "yarn test --watch",
     "lint": "eslint ./src --ext .js,.cjs,.ts --no-error-on-unmatched-pattern",
     "lint:fix": "yarn lint --fix",

--- a/packages/arch3-proto/package.json
+++ b/packages/arch3-proto/package.json
@@ -46,7 +46,7 @@
     "clean": "rimraf ./build",
     "codegen": "./scripts/codegen.js",
     "build": "yarn clean && tsc --build",
-    "test": "DOTENV_CONFIG_PATH=../../.env jest --no-cache",
+    "test": "DOTENV_CONFIG_PATH=../../.env jest",
     "test:watch": "jest --watch",
     "lint": "eslint ./src --ext .js,.cjs,.ts --no-error-on-unmatched-pattern",
     "lint:fix": "yarn lint --fix",


### PR DESCRIPTION
The jest cache doesn't affect CI, but improves the test execution time on multiple local runs.