### PR TITLE
feat(arch3-core): estimate fees before signing

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -216,6 +216,10 @@ module.exports = {
       extends: ['plugin:jest/all'],
       rules: {
         'jest/consistent-test-it': 'error',
+        'jest/expect-expect': ['error', {
+          'assertFunctionNames': ['expect*', 'assert*'],
+          'additionalTestBlockFunctions': []
+        }],
         'jest/no-conditional-in-test': 'warn',
         'jest/prefer-comparison-matcher': 'error',
         'jest/prefer-equality-matcher': 'error',

--- a/.yarn/versions/a7a85de0.yml
+++ b/.yarn/versions/a7a85de0.yml
@@ -1,0 +1,3 @@
+releases:
+  "@archwayhq/arch3-core": minor
+  "@archwayhq/arch3.js": minor

--- a/packages/arch3-core/package.json
+++ b/packages/arch3-core/package.json
@@ -51,6 +51,7 @@
   "dependencies": {
     "@archwayhq/arch3-proto": "workspace:^",
     "@cosmjs/cosmwasm-stargate": "^0.30.1",
+    "@cosmjs/math": "^0.30.1",
     "@cosmjs/proto-signing": "^0.30.1",
     "@cosmjs/stargate": "^0.30.1",
     "@cosmjs/tendermint-rpc": "^0.30.1"

--- a/packages/arch3-core/package.json
+++ b/packages/arch3-core/package.json
@@ -50,11 +50,13 @@
   },
   "dependencies": {
     "@archwayhq/arch3-proto": "workspace:^",
+    "@cosmjs/amino": "^0.30.1",
     "@cosmjs/cosmwasm-stargate": "^0.30.1",
     "@cosmjs/math": "^0.30.1",
     "@cosmjs/proto-signing": "^0.30.1",
     "@cosmjs/stargate": "^0.30.1",
-    "@cosmjs/tendermint-rpc": "^0.30.1"
+    "@cosmjs/tendermint-rpc": "^0.30.1",
+    "lodash": "^4.17.21"
   },
   "devDependencies": {
     "@microsoft/eslint-formatter-sarif": "^3.0",

--- a/packages/arch3-core/src/archwayclient.spec.ts
+++ b/packages/arch3-core/src/archwayclient.spec.ts
@@ -93,8 +93,8 @@ describe('ArchwayClient', () => {
       const response = await client.getOutstandingRewards(aliceAddress);
 
       expect(response.rewardsAddress).toBe(aliceAddress);
-      expect(response.totalRewards).toHaveLength(0);
-      expect(response.totalRecords).toBe(0);
+      expect(response.totalRewards).not.toHaveLength(0);
+      expect(response.totalRecords).toBeGreaterThan(0);
 
       client.disconnect();
     });
@@ -113,7 +113,7 @@ describe('ArchwayClient', () => {
       const client = await ArchwayClient.connect(archwayd.endpoint);
       const response = await client.getAllRewardsRecords(aliceAddress);
 
-      expect(response).toHaveLength(0);
+      expect(response).not.toHaveLength(0);
 
       client.disconnect();
     });

--- a/packages/arch3-core/src/archwayclient.spec.ts
+++ b/packages/arch3-core/src/archwayclient.spec.ts
@@ -1,3 +1,6 @@
+import { coin } from '@cosmjs/amino';
+import { Decimal } from '@cosmjs/math';
+
 import { ArchwayClient } from './archwayclient';
 
 const archwayd = {
@@ -7,7 +10,13 @@ const archwayd = {
   denom: 'uarch',
 };
 
-const contractAddress = 'archway1ry0fa2zdu46gu5v9r0lx5x7klmued4hz8lcekzdf6yutllxvhd4sqh452d';
+const contracts = {
+  voter: {
+    codeId: parseInt(process.env.VOTER_CONTRACT_CODE_ID || '1'),
+    addresses: process.env.VOTER_CONTRACT_ADDRESSES?.split(' ') || []
+  },
+};
+const contractAddress = contracts.voter.addresses[0];
 const aliceAddress = 'archway1ecak50zhujddqd639xw4ejghnyrrc6jlwnlgwt';
 
 describe('ArchwayClient', () => {
@@ -44,13 +53,15 @@ describe('ArchwayClient', () => {
 
     it('estimate fees without contract', async () => {
       const client = await ArchwayClient.connect(archwayd.endpoint);
-      const response = await client.getEstimateTxFees(1);
+      const response = await client.getEstimateTxFees();
 
-      expect(response.gasLimit).toBeGreaterThan(0);
+      expect(response.gasLimit).toBeUndefined();
       expect(response.gasUnitPrice).toMatchObject({
         denom: archwayd.denom,
-        amount: expect.stringMatching(/\d+/),
+        amount: expect.any(Decimal),
       });
+      const gasUnitPriceAmount = response.gasUnitPrice?.amount;
+      expect(gasUnitPriceAmount?.isLessThan(Decimal.one(gasUnitPriceAmount?.fractionalDigits))).toBeTruthy();
       expect(response.contractAddress).toBeUndefined();
       expect(response.estimatedFee).toHaveLength(0);
 
@@ -61,11 +72,13 @@ describe('ArchwayClient', () => {
       const client = await ArchwayClient.connect(archwayd.endpoint);
       const response = await client.getEstimateTxFees(1, contractAddress);
 
-      expect(response.gasLimit).toBeGreaterThan(0);
+      expect(response.gasLimit).toBe(1);
       expect(response.gasUnitPrice).toMatchObject({
         denom: archwayd.denom,
-        amount: expect.stringMatching(/\d+/),
+        amount: expect.any(Decimal),
       });
+      const gasUnitPriceAmount = response.gasUnitPrice?.amount;
+      expect(gasUnitPriceAmount?.isLessThan(Decimal.one(gasUnitPriceAmount?.fractionalDigits))).toBeTruthy();
       expect(response.contractAddress).toBe(contractAddress);
       expect(response.estimatedFee).toContainEqual({
         denom: archwayd.denom,
@@ -105,12 +118,22 @@ describe('ArchwayClient', () => {
       client.disconnect();
     });
 
-    it('check flat fee are coming back', async () => {
+    it('check contract premium are coming back', async () => {
       const client = await ArchwayClient.connect(archwayd.endpoint);
       const response = await client.getContractPremium(contractAddress);
 
       expect(response.contractAddress).toBe(contractAddress);
-      expect(response.flatFee).toBeDefined();
+      expect(response.flatFee).toMatchObject(coin(100, archwayd.denom));
+
+      client.disconnect();
+    });
+
+    it('check does not fail when contract premium is not set', async () => {
+      const client = await ArchwayClient.connect(archwayd.endpoint);
+      const response = await client.getContractPremium(contracts.voter.addresses[2]);
+
+      expect(response.contractAddress).toBe(contracts.voter.addresses[2]);
+      expect(response.flatFee).toBeUndefined();
 
       client.disconnect();
     });

--- a/packages/arch3-core/src/archwayclient.spec.ts
+++ b/packages/arch3-core/src/archwayclient.spec.ts
@@ -80,10 +80,7 @@ describe('ArchwayClient', () => {
       const gasUnitPriceAmount = response.gasUnitPrice?.amount;
       expect(gasUnitPriceAmount?.isLessThan(Decimal.one(gasUnitPriceAmount?.fractionalDigits))).toBeTruthy();
       expect(response.contractAddress).toBe(contractAddress);
-      expect(response.estimatedFee).toContainEqual({
-        denom: archwayd.denom,
-        amount: '100',
-      });
+      expect(response.estimatedFee).toContainEqual(coin(1000, archwayd.denom));
 
       client.disconnect();
     });
@@ -123,7 +120,7 @@ describe('ArchwayClient', () => {
       const response = await client.getContractPremium(contractAddress);
 
       expect(response.contractAddress).toBe(contractAddress);
-      expect(response.flatFee).toMatchObject(coin(100, archwayd.denom));
+      expect(response.flatFee).toMatchObject(coin(1000, archwayd.denom));
 
       client.disconnect();
     });

--- a/packages/arch3-core/src/archwayclient.ts
+++ b/packages/arch3-core/src/archwayclient.ts
@@ -60,7 +60,7 @@ export class ArchwayClient extends CosmWasmClient implements IArchwayQueryClient
     return await this.archwayQueryClient.getContractPremium(contractAddress);
   }
 
-  public async getEstimateTxFees(gasLimit: number, contractAddress?: string): Promise<EstimateTxFees> {
+  public async getEstimateTxFees(gasLimit?: number, contractAddress?: string): Promise<EstimateTxFees> {
     return await this.archwayQueryClient.getEstimateTxFees(gasLimit, contractAddress);
   }
 

--- a/packages/arch3-core/src/modules/rewards/queries.ts
+++ b/packages/arch3-core/src/modules/rewards/queries.ts
@@ -18,7 +18,7 @@ export interface RewardsExtension {
     readonly contractMetadata: (contractAddress: string) => Promise<QueryContractMetadataResponse>;
     readonly blockRewardsTracking: () => Promise<QueryBlockRewardsTrackingResponse>;
     readonly rewardsPool: () => Promise<QueryRewardsPoolResponse>;
-    readonly estimateTxFees: (gasLimit: number, contractAddress?: string) => Promise<QueryEstimateTxFeesResponse>;
+    readonly estimateTxFees: (gasLimit: number, contractAddress: string) => Promise<QueryEstimateTxFeesResponse>;
     readonly rewardsRecords: (rewardsAddress: string, paginationKey?: Uint8Array) => Promise<QueryRewardsRecordsResponse>;
     readonly outstandingRewards: (rewardsAddress: string) => Promise<QueryOutstandingRewardsResponse>;
     readonly flatFee: (contractAddress: string) => Promise<QueryFlatFeeResponse>;
@@ -40,20 +40,14 @@ export function setupRewardsExtension(base: QueryClient): RewardsExtension {
       contractMetadata: (contractAddress: string) => queryService.contractMetadata({ contractAddress }),
       blockRewardsTracking: () => queryService.blockRewardsTracking(),
       rewardsPool: () => queryService.rewardsPool(),
-      estimateTxFees: (gasLimit: number, contractAddress: string) => {
-        const request = {
-          gasLimit: Long.fromNumber(gasLimit),
-          contractAddress,
-        };
-        return queryService.estimateTxFees(request);
-      },
-      rewardsRecords: (rewardsAddress: string, paginationKey?: Uint8Array) => {
-        const request = {
-          rewardsAddress,
-          pagination: createPagination(paginationKey),
-        };
-        return queryService.rewardsRecords(request);
-      },
+      estimateTxFees: (gasLimit: number, contractAddress: string) => queryService.estimateTxFees({
+        gasLimit: Long.fromNumber(gasLimit),
+        contractAddress,
+      }),
+      rewardsRecords: (rewardsAddress: string, paginationKey?: Uint8Array) => queryService.rewardsRecords({
+        rewardsAddress,
+        pagination: createPagination(paginationKey),
+      }),
       outstandingRewards: (rewardsAddress: string) => queryService.outstandingRewards({ rewardsAddress }),
       flatFee: (contractAddress: string) => queryService.flatFee({ contractAddress }),
     }

--- a/packages/arch3-core/src/queryclient.ts
+++ b/packages/arch3-core/src/queryclient.ts
@@ -83,7 +83,7 @@ export interface IArchwayQueryClient {
    * @param rewardsAddress - Address set in a contract's metadata to receive rewards.
    * @returns All rewards records for the given address.
    *
-   * @see {@link ArchwayClient.getContractMetadata}
+   * @see {@link IArchwayQueryClient.getContractMetadata}
    */
   getAllRewardsRecords(rewardsAddress: string): Promise<readonly RewardsRecord[]>;
 }

--- a/packages/arch3-core/src/queryclient.ts
+++ b/packages/arch3-core/src/queryclient.ts
@@ -2,6 +2,8 @@ import { setupWasmExtension, WasmExtension } from '@cosmjs/cosmwasm-stargate';
 import {
   AuthExtension,
   BankExtension,
+  decodeCosmosSdkDecFromProto,
+  GasPrice,
   QueryClient,
   setupAuthExtension,
   setupBankExtension,
@@ -58,7 +60,7 @@ export interface IArchwayQueryClient {
    * @param contractAddress - Contract address to include the flat fees in the estimate.
    * @returns The estimated transaction fees for the lastest block.
    */
-  getEstimateTxFees(gasLimit: number, contractAddress?: string): Promise<EstimateTxFees>;
+  getEstimateTxFees(gasLimit?: number, contractAddress?: string): Promise<EstimateTxFees>;
 
   /**
    * Queries the unclaimed rewards available for a given address.
@@ -119,11 +121,13 @@ class ArchwayQueryClientImpl implements IArchwayQueryClient {
       block: { txRewards: txRewardsResponse, inflationRewards }
     } = await client.rewards.blockRewardsTracking();
 
-    const txRewards = txRewardsResponse.map(txReward => { return {
-      txId: txReward.txId.toNumber(),
-      height: txReward.height.toNumber(),
-      feeRewards: txReward.feeRewards,
-    }; });
+    const txRewards = txRewardsResponse.map(txReward => {
+      return {
+        txId: txReward.txId.toNumber(),
+        height: txReward.height.toNumber(),
+        feeRewards: txReward.feeRewards,
+      };
+    });
 
     return {
       inflationRewards: {
@@ -150,17 +154,32 @@ class ArchwayQueryClientImpl implements IArchwayQueryClient {
 
   public async getContractPremium(contractAddress: string): Promise<ContractPremium> {
     const client = this.forceGetQueryClient();
-    const { flatFeeAmount } = await client.rewards.flatFee(contractAddress);
-
-    return {
-      contractAddress,
-      flatFee: flatFeeAmount,
-    };
+    try {
+      const { flatFeeAmount } = await client.rewards.flatFee(contractAddress);
+      return {
+        contractAddress,
+        flatFee: flatFeeAmount,
+      };
+    } catch (e) {
+      return {
+        contractAddress,
+      };
+    }
   }
 
-  public async getEstimateTxFees(gasLimit: number, contractAddress?: string): Promise<EstimateTxFees> {
+  public async getEstimateTxFees(gasLimit?: number, contractAddress?: string): Promise<EstimateTxFees> {
     const client = this.forceGetQueryClient();
-    const { estimatedFee, gasUnitPrice } = await client.rewards.estimateTxFees(gasLimit, contractAddress || '');
+    const {
+      estimatedFee,
+      gasUnitPrice: { amount: gasAmount, denom: gasDenom }
+    } = await client.rewards.estimateTxFees(gasLimit ?? 0, contractAddress ?? '');
+
+    // The RPC queries do not include the decimal precision fot types.Dec,
+    // so we need to manually decode the gas amount from the proto, as suggested in
+    // https://github.com/osmosis-labs/telescope/issues/247#issuecomment-1292407464
+    // See also: https://github.com/cosmos/cosmos-sdk/issues/10863
+    const gasUnitPriceAmount = decodeCosmosSdkDecFromProto(gasAmount);
+    const gasUnitPrice = new GasPrice(gasUnitPriceAmount, gasDenom);
 
     return {
       gasLimit,

--- a/packages/arch3-core/src/signingarchwayclient.ts
+++ b/packages/arch3-core/src/signingarchwayclient.ts
@@ -322,7 +322,7 @@ export class SigningArchwayClient extends SigningCosmWasmClient implements IArch
     return await this.archwayQueryClient.getContractPremium(contractAddress);
   }
 
-  public async getEstimateTxFees(gasLimit: number, contractAddress?: string): Promise<EstimateTxFees> {
+  public async getEstimateTxFees(gasLimit?: number, contractAddress?: string): Promise<EstimateTxFees> {
     return await this.archwayQueryClient.getEstimateTxFees(gasLimit, contractAddress);
   }
 

--- a/packages/arch3-core/src/signingarchwayclient.ts
+++ b/packages/arch3-core/src/signingarchwayclient.ts
@@ -1,4 +1,5 @@
 import { Long } from '@archwayhq/arch3-proto/helpers';
+import { Coin, addCoins } from '@cosmjs/amino';
 import {
   createWasmAminoConverters,
   HttpEndpoint,
@@ -6,18 +7,21 @@ import {
   SigningCosmWasmClientOptions
 } from '@cosmjs/cosmwasm-stargate';
 import { wasmTypes } from '@cosmjs/cosmwasm-stargate/build/modules';
-import { Coin, EncodeObject, OfflineSigner, Registry } from '@cosmjs/proto-signing';
+import { EncodeObject, OfflineSigner, Registry } from '@cosmjs/proto-signing';
 import {
   AminoTypes,
   assertIsDeliverTxSuccess,
+  calculateFee,
   createDefaultAminoConverters,
   defaultRegistryTypes,
   DeliverTxResponse,
   Event,
+  GasPrice,
   logs,
   StdFee
 } from '@cosmjs/stargate';
 import { Tendermint34Client, TendermintClient } from '@cosmjs/tendermint-rpc';
+import _ from 'lodash';
 
 import { createRewardsAminoConverters, RewardsMsgEncoder, rewardsTypes } from './modules';
 import { IArchwayQueryClient, createArchwayQueryClient } from './queryclient';
@@ -91,11 +95,17 @@ function buildResult(response: DeliverTxResponseWithLogs): TxResult {
   };
 }
 
+const flatFeeRequiredTypes: readonly string[] = [
+  '/cosmwasm.wasm.v1.MsgExecuteContract',
+  '/cosmwasm.wasm.v1.MsgMigrateContract',
+];
+
 /**
  * Extension to the {@link SigningCosmWasmClient} for transacting with Archway's modules.
  */
 export class SigningArchwayClient extends SigningCosmWasmClient implements IArchwayQueryClient {
   private readonly archwayQueryClient: IArchwayQueryClient;
+  private readonly defaultGasPrice?: GasPrice;
 
   protected constructor(tmClient: TendermintClient | undefined, signer: OfflineSigner, options: SigningCosmWasmClientOptions) {
     const {
@@ -105,9 +115,11 @@ export class SigningArchwayClient extends SigningCosmWasmClient implements IArch
         ...createWasmAminoConverters(),
         ...createRewardsAminoConverters(),
       }),
+      gasPrice,
     } = options;
     super(tmClient, signer, { ...options, registry, aminoTypes });
     this.archwayQueryClient = createArchwayQueryClient(tmClient);
+    this.defaultGasPrice = gasPrice;
   }
 
   /**
@@ -290,6 +302,60 @@ export class SigningArchwayClient extends SigningCosmWasmClient implements IArch
       ...buildResult(response),
       rewardsAddress,
       rewards,
+    };
+  }
+
+  /**
+   * Creates a transaction with the given messages, fee and memo. Then signs and broadcasts the transaction.
+   *
+   * @param signerAddress - The address that will sign transactions using this instance.
+   *                        The signer must be able to sign with this address.
+   * @param messages - The messages to include in the transaction. The messages types should be registered in the
+   *                  {@link SigningArchwayClient.registry} when the client is instantiated.
+   * @param fee - Fee to pay for the transaction. Use 'auto' to calculate the fee automatically.
+   * @param memo - Optional memo to add to the transaction.
+   * @returns A {@link DeliverTxResponse} after successfully broadcasting the transaction.
+   */
+  public override async signAndBroadcast(
+    signerAddress: string,
+    messages: readonly EncodeObject[],
+    fee: number | StdFee | 'auto',
+    memo?: string
+  ): Promise<DeliverTxResponse> {
+    let usedFee: StdFee;
+    if (fee === 'auto' || typeof fee === 'number') {
+      const gasEstimation = await this.simulate(signerAddress, messages, memo);
+      const gasPrice = this.defaultGasPrice ?? (await this.getEstimateTxFees(gasEstimation)).gasUnitPrice;
+      const multiplier = typeof fee === 'number' ? fee : 1.3;
+      const estimatedFee = calculateFee(Math.round(gasEstimation * multiplier), gasPrice);
+      usedFee = await this.calculateFlatFee(messages, estimatedFee);
+    } else {
+      usedFee = fee;
+    }
+    return super.signAndBroadcast(signerAddress, messages, usedFee, memo);
+  }
+
+  private async calculateFlatFee(messages: readonly EncodeObject[], estimatedFee: StdFee): Promise<StdFee> {
+    const _getContractPremium = _.memoize((contractAddress: string) => this.getContractPremium(contractAddress));
+    const flatFees = await Promise.all(
+      messages
+        .filter(({ typeUrl }) => flatFeeRequiredTypes.includes(typeUrl))
+        .map(({ value }) => {
+          const contractAddress = _.get(value, 'contract') as string;
+          return _getContractPremium(contractAddress);
+        })
+    );
+    const cleanedFlatFees = _.compact(flatFees.map(({ flatFee }) => flatFee));
+    if (_.isEmpty(cleanedFlatFees)) {
+      return estimatedFee;
+    }
+
+    const totalFee = [...estimatedFee.amount, ...cleanedFlatFees]
+      .reduce((acc, fee) => addCoins(acc, fee));
+
+    return {
+      ...estimatedFee,
+      amount: [totalFee]
     };
   }
 

--- a/packages/arch3-core/src/types.ts
+++ b/packages/arch3-core/src/types.ts
@@ -1,4 +1,4 @@
-import { Coin } from '@cosmjs/stargate';
+import { Coin, GasPrice } from '@cosmjs/stargate';
 
 /**
  * Defines the contract rewards distribution options for a particular contract.
@@ -47,9 +47,9 @@ export interface ContractPremium {
  */
 export interface EstimateTxFees {
   /** Maximum amount of gas to be used in this transaction. */
-  readonly gasLimit: number;
+  readonly gasLimit?: number;
   /** Minimum transaction fee per gas unit. */
-  readonly gasUnitPrice?: Coin;
+  readonly gasUnitPrice?: GasPrice;
   /** Contract address used to query for premium fees. */
   readonly contractAddress?: string;
   /** Estimated transaction fee for a given gas limit and contract premium. */

--- a/scripts/start-local-node.sh
+++ b/scripts/start-local-node.sh
@@ -340,7 +340,7 @@ for i in {0..1}; do
     archwayd-tx rewards set-flat-fee \
       --from "${alice_addresses[i]}" \
       "${contract_addresses[i]}" \
-      "100${denom}"
+      "1000${denom}"
   )"
   validate-tx "$tx_result" "failed to set flat fee!"
   tx_hash="$(jq -r '.txhash' <<<"${tx_result}")"

--- a/yarn.lock
+++ b/yarn.lock
@@ -40,6 +40,7 @@ __metadata:
   dependencies:
     "@archwayhq/arch3-proto": "workspace:^"
     "@cosmjs/cosmwasm-stargate": ^0.30.1
+    "@cosmjs/math": ^0.30.1
     "@cosmjs/proto-signing": ^0.30.1
     "@cosmjs/stargate": ^0.30.1
     "@cosmjs/tendermint-rpc": ^0.30.1

--- a/yarn.lock
+++ b/yarn.lock
@@ -39,6 +39,7 @@ __metadata:
   resolution: "@archwayhq/arch3-core@workspace:packages/arch3-core"
   dependencies:
     "@archwayhq/arch3-proto": "workspace:^"
+    "@cosmjs/amino": ^0.30.1
     "@cosmjs/cosmwasm-stargate": ^0.30.1
     "@cosmjs/math": ^0.30.1
     "@cosmjs/proto-signing": ^0.30.1
@@ -58,6 +59,7 @@ __metadata:
     eslint-plugin-jsdoc: ^43.1.1
     eslint-plugin-node: ^11.1.0
     jest: ^29.5.0
+    lodash: ^4.17.21
     rimraf: ^3.0.2
     ts-jest: ^29.1.0
     ts-node: ^10.9.1


### PR DESCRIPTION
Add support to the [minimum consensus fee mechanism](https://github.com/archway-network/archway/blob/main/x/rewards/spec/01_state.md#minconsensusfee) and [contract premiums](https://github.com/archway-network/archway/blob/main/x/rewards/spec/01_state.md#contract-flat-fees) by estimating the fees before signing and broadcasting.