### PR TITLE
build!: update package exports

### DIFF
--- a/.yarn/versions/e0987bab.yml
+++ b/.yarn/versions/e0987bab.yml
@@ -1,0 +1,3 @@
+releases:
+  "@archwayhq/arch3-core": minor
+  "@archwayhq/arch3.js": minor

--- a/packages/arch3-core/src/index.ts
+++ b/packages/arch3-core/src/index.ts
@@ -1,5 +1,3 @@
-export * from '@cosmjs/cosmwasm-stargate';
-
 export { ArchwayClient } from './archwayclient';
 
 export {

--- a/packages/arch3-core/src/index.ts
+++ b/packages/arch3-core/src/index.ts
@@ -1,6 +1,17 @@
 export * from '@cosmjs/cosmwasm-stargate';
 
 export { ArchwayClient } from './archwayclient';
+
+export {
+  createRewardsAminoConverters,
+  RewardsExtension,
+  RewardsMsgEncoder,
+  rewardsTypes,
+  setupRewardsExtension,
+} from './modules';
+
+export * from './queryclient';
+
 export {
   SetContractMetadataResult,
   SetContractPremiumResult,
@@ -9,6 +20,4 @@ export {
   WithdrawContractRewardsResult,
 } from './signingarchwayclient';
 
-export * from './modules';
 export * from './types';
-export * from './queryclient';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
 export * from '@archwayhq/arch3-core';
+export * from '@archwayhq/arch3-proto';


### PR DESCRIPTION
- export arch3-proto in arch3.js
- add extra types and functions exports to arch3-core

BREAKING CHANGE: the package @cosmjs/cosmwasm-stargate is not re-exported with @archwayhq/arch-core anymore