### PR TITLE
fix: package path resolutions for the workspace

### DIFF
--- a/.yarn/versions/dc753c82.yml
+++ b/.yarn/versions/dc753c82.yml
@@ -1,0 +1,3 @@
+releases:
+  "@archwayhq/arch3-core": minor
+  "@archwayhq/arch3.js": minor

--- a/package.json
+++ b/package.json
@@ -40,6 +40,10 @@
   ],
   "main": "build/index.js",
   "types": "build/index.d.js",
+  "exports": {
+    ".": "./build/index.js",
+    "./*": "./build/*.js"
+  },
   "scripts": {
     "postinstall": "husky install",
     "prepack": "pinst --disable && yarn run build:all",
@@ -65,6 +69,15 @@
     "*.ts": [
       "yarn run lint:fix:all --cache"
     ]
+  },
+  "resolutions": {
+    "@cosmjs/amino": "^0.30.1",
+    "@cosmjs/cosmwasm-stargate": "^0.30.1",
+    "@cosmjs/math": "^0.30.1",
+    "@cosmjs/proto-signing": "^0.30.1",
+    "@cosmjs/stargate": "^0.30.1",
+    "@cosmjs/tendermint-rpc": "^0.30.1",
+    "long": "^5.2.3"
   },
   "dependencies": {
     "@archwayhq/arch3-core": "workspace:^",

--- a/packages/arch3-core/package.json
+++ b/packages/arch3-core/package.json
@@ -35,11 +35,11 @@
     "./*.md",
     "./LICENSE"
   ],
-  "main": "build/arch3-core/src/index.js",
-  "types": "build/arch3-core/src/index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "exports": {
-    ".": "./build/arch3-core/index.js",
-    "./*": "./build/arch3-core/*.js"
+    ".": "./build/index.js",
+    "./*": "./build/*.js"
   },
   "scripts": {
     "prepack": "yarn run build",
@@ -60,7 +60,8 @@
     "@cosmjs/proto-signing": "^0.30.1",
     "@cosmjs/stargate": "^0.30.1",
     "@cosmjs/tendermint-rpc": "^0.30.1",
-    "lodash": "^4.17.21"
+    "lodash": "^4.17.21",
+    "long": "^5.2.0"
   },
   "devDependencies": {
     "@microsoft/eslint-formatter-sarif": "^3.0",

--- a/packages/arch3-core/src/modules/rewards/queries.ts
+++ b/packages/arch3-core/src/modules/rewards/queries.ts
@@ -1,3 +1,4 @@
+import { archway } from '@archwayhq/arch3-proto';
 import {
   QueryBlockRewardsTrackingResponse,
   QueryContractMetadataResponse,
@@ -7,10 +8,9 @@ import {
   QueryParamsResponse,
   QueryRewardsPoolResponse,
   QueryRewardsRecordsResponse
-} from '@archwayhq/arch3-proto/archway/rewards/v1/query';
-import { createRpcQueryExtension } from '@archwayhq/arch3-proto/archway/rewards/v1/query.rpc.Query';
-import { Long } from '@archwayhq/arch3-proto/helpers';
+} from '@archwayhq/arch3-proto/build/archway/rewards/v1/query';
 import { createPagination, QueryClient } from '@cosmjs/stargate';
+import Long from 'long';
 
 export interface RewardsExtension {
   readonly rewards: {
@@ -32,7 +32,7 @@ export interface RewardsExtension {
  * @returns A {@link RewardsExtension}.
  */
 export function setupRewardsExtension(base: QueryClient): RewardsExtension {
-  const queryService = createRpcQueryExtension(base);
+  const queryService = archway.rewards.v1.createRpcQueryExtension(base);
 
   return {
     rewards: {

--- a/packages/arch3-core/src/modules/rewards/tx.ts
+++ b/packages/arch3-core/src/modules/rewards/tx.ts
@@ -1,12 +1,11 @@
-import { AminoConverter } from '@archwayhq/arch3-proto/archway/rewards/v1/tx.amino';
-import { MessageComposer } from '@archwayhq/arch3-proto/archway/rewards/v1/tx.registry';
+import { archway } from '@archwayhq/arch3-proto';
 import type { AminoConverters } from '@cosmjs/stargate';
 
-export { registry as rewardsTypes } from '@archwayhq/arch3-proto/archway/rewards/v1/tx.registry';
+export const rewardsTypes = archway.rewards.v1.registry;
 
-export const createRewardsAminoConverters: () => AminoConverters = () => AminoConverter;
+export const createRewardsAminoConverters: () => AminoConverters = () => archway.rewards.v1.AminoConverter;
 
 /**
  * Encodes the transaction messages for the `x/rewards` module.
  */
-export const RewardsMsgEncoder = MessageComposer.fromPartial;
+export const RewardsMsgEncoder = archway.rewards.v1.MessageComposer.fromPartial;

--- a/packages/arch3-core/src/signingarchwayclient.ts
+++ b/packages/arch3-core/src/signingarchwayclient.ts
@@ -1,4 +1,3 @@
-import { Long } from '@archwayhq/arch3-proto/helpers';
 import { Coin, addCoins } from '@cosmjs/amino';
 import {
   createWasmAminoConverters,
@@ -22,6 +21,7 @@ import {
 } from '@cosmjs/stargate';
 import { Tendermint34Client, TendermintClient } from '@cosmjs/tendermint-rpc';
 import _ from 'lodash';
+import Long from 'long';
 
 import { createRewardsAminoConverters, RewardsMsgEncoder, rewardsTypes } from './modules';
 import { IArchwayQueryClient, createArchwayQueryClient } from './queryclient';

--- a/packages/arch3-core/tsconfig.json
+++ b/packages/arch3-core/tsconfig.json
@@ -3,11 +3,6 @@
   "compilerOptions": {
     "baseUrl": ".",
     "outDir": "build",
-    "rootDirs": [
-      "src",
-      "../arch3-proto/src",
-      "../arch3-proto/generated"
-    ],
     "paths": {
       "@archwayhq/arch3-proto/*": [
         "../arch3-proto/src/*",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,19 +2,13 @@
   "compilerOptions": {
     "baseUrl": ".",
     "outDir": "build",
-    "rootDirs": [
-      "src",
-      "packages/arch3-core/src",
-      "packages/arch3-proto/src",
-      "packages/arch3-proto/generated"
-    ],
     "paths": {
       "@archwayhq/arch3-core/*": [
-        "./packages/arch3-core/src/*"
+        "packages/arch3-core/src/*"
       ],
       "@archwayhq/arch3-proto/*": [
-        "./packages/arch3-proto/src/*",
-        "./packages/arch3-proto/generated/*"
+        "packages/arch3-proto/src/*",
+        "packages/arch3-proto/generated/*"
       ]
     },
     "declaration": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -60,6 +60,7 @@ __metadata:
     eslint-plugin-node: ^11.1.0
     jest: ^29.5.0
     lodash: ^4.17.21
+    long: ^5.2.0
     rimraf: ^3.0.2
     ts-jest: ^29.1.0
     ts-node: ^10.9.1
@@ -8930,21 +8931,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"long@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "long@npm:4.0.0"
-  checksum: 16afbe8f749c7c849db1f4de4e2e6a31ac6e617cead3bdc4f9605cb703cd20e1e9fc1a7baba674ffcca57d660a6e5b53a9e236d7b25a295d3855cca79cc06744
-  languageName: node
-  linkType: hard
-
-"long@npm:^5.2.0":
-  version: 5.2.1
-  resolution: "long@npm:5.2.1"
-  checksum: 9264da12d1b7df67e5aa6da4498144293caf1ad12e7f092efe4e9a2d32c53f0bbf7334f7cef997080a2a3af061142558ab366efa71698d98b1cdb883477445a7
-  languageName: node
-  linkType: hard
-
-"long@npm:^5.2.1":
+"long@npm:^5.2.3":
   version: 5.2.3
   resolution: "long@npm:5.2.3"
   checksum: 885ede7c3de4facccbd2cacc6168bae3a02c3e836159ea4252c87b6e34d40af819824b2d4edce330bfb5c4d6e8ce3ec5864bdcf9473fa1f53a4f8225860e5897


### PR DESCRIPTION
After packing the packages and importing them into a project, `arch3.js` could not resolve the `arch3-core` and `arch3-proto` paths. This fix changes the path resolution by using only types exported at the top level of the packages.