### PR TITLE
fix(core): update type for options argument

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Fixes
+
+#### **arch3-core**
+
+- use the type `SigningArchwayClientOptions` for the `options` in all factory
+  methods of the `SigningArchwayClient` (#89)
+
 ## v0.3.0 (2023-05-30)
 
 ### New feature

--- a/packages/arch3-core/src/signingarchwayclient.spec.ts
+++ b/packages/arch3-core/src/signingarchwayclient.spec.ts
@@ -1,9 +1,8 @@
 import { Coin, addCoins, coin, coins } from '@cosmjs/amino';
-import { SigningCosmWasmClientOptions } from '@cosmjs/cosmwasm-stargate';
 import { AccountData, DirectSecp256k1HdWallet, decodeTxRaw, makeCosmoshubPath } from '@cosmjs/proto-signing';
 import { GasPrice, StdFee, calculateFee } from '@cosmjs/stargate';
 
-import { ContractMetadata, SigningArchwayClient } from '.';
+import { ContractMetadata, SigningArchwayClient, SigningArchwayClientOptions } from '.';
 
 const archwayd = {
   chainId: 'local-1',
@@ -34,7 +33,7 @@ async function getWalletWithAccounts(): Promise<[DirectSecp256k1HdWallet, readon
 
 const flatFee = coin(1000, archwayd.denom);
 
-const clientOptions: SigningCosmWasmClientOptions = {
+const clientOptions: SigningArchwayClientOptions = {
   broadcastPollIntervalMs: 200,
   broadcastTimeoutMs: 8_000,
 };

--- a/packages/arch3-core/src/signingarchwayclient.ts
+++ b/packages/arch3-core/src/signingarchwayclient.ts
@@ -155,7 +155,7 @@ export class SigningArchwayClient extends SigningCosmWasmClient implements IArch
   public static override async connectWithSigner(
     endpoint: string | HttpEndpoint,
     signer: OfflineSigner,
-    options: SigningCosmWasmClientOptions = {},
+    options: SigningArchwayClientOptions = {},
   ): Promise<SigningArchwayClient> {
     const tmClient = await Tendermint34Client.connect(endpoint);
     return SigningArchwayClient.createWithSigner(tmClient, signer, options);
@@ -173,7 +173,7 @@ export class SigningArchwayClient extends SigningCosmWasmClient implements IArch
   public static override async createWithSigner(
     tmClient: TendermintClient,
     signer: OfflineSigner,
-    options: SigningCosmWasmClientOptions = {},
+    options: SigningArchwayClientOptions = {},
   ): Promise<SigningArchwayClient> {
     return new SigningArchwayClient(tmClient, signer, options);
   }
@@ -195,7 +195,7 @@ export class SigningArchwayClient extends SigningCosmWasmClient implements IArch
   /* eslint-disable-next-line @typescript-eslint/require-await */
   public static override async offline(
     signer: OfflineSigner,
-    options: SigningCosmWasmClientOptions = {},
+    options: SigningArchwayClientOptions = {},
   ): Promise<SigningArchwayClient> {
     return new SigningArchwayClient(undefined, signer, options);
   }


### PR DESCRIPTION
Use the type `SigningArchwayClientOptions` for the `options` in all factory methods of the `SigningArchwayClient`