### PR TITLE
fix: Gracefully handle withdrawing when no rewards exist

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Fixes
+
+#### **arch3-core**
+
+- gracefully handle withdrawing reward contracts when no rewards exist (#91)
+
 ## v0.3.1 (2023-06-02)
 
 ### Fixes
@@ -66,4 +74,5 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 #### **arch3-core**
 
 - added the `ArchwayClient` (#18)
+- added the `SigningArchwayClient` (#22)
 - added the `SigningArchwayClient` (#22)

--- a/packages/arch3-core/src/signingarchwayclient.spec.ts
+++ b/packages/arch3-core/src/signingarchwayclient.spec.ts
@@ -383,13 +383,11 @@ describe('SigningArchwayClient', () => {
       const [wallet, accounts] = await getWalletWithAccounts();
       const client = await SigningArchwayClient.connectWithSigner(archwayd.endpoint, wallet, clientOptions);
 
-      const rewardsAddress = accounts[3].address;
+      const rewardsAddress = accounts[1].address;
 
-      // Withdrawing rewards twice to make sure the second time there are no rewards to claim
-      await client.withdrawContractRewards(rewardsAddress, 0, 'auto');
-      const secondResult = await client.withdrawContractRewards(rewardsAddress, 0, 'auto');
+      const result = await client.withdrawContractRewards(rewardsAddress, 0, 'auto');
 
-      expect(secondResult).toMatchObject({
+      expect(result).toMatchObject({
         height: expect.any(Number),
         transactionHash: expect.any(String),
         gasWanted: expect.any(Number),
@@ -397,8 +395,8 @@ describe('SigningArchwayClient', () => {
         rewardsAddress: rewardsAddress,
         rewards: expect.arrayContaining([]),
       });
-      expect(secondResult.logs).not.toHaveLength(0);
-      expect(secondResult.events).not.toHaveLength(0);
+      expect(result.logs).not.toHaveLength(0);
+      expect(result.events).not.toHaveLength(0);
 
       client.disconnect();
     });

--- a/packages/arch3-core/src/signingarchwayclient.ts
+++ b/packages/arch3-core/src/signingarchwayclient.ts
@@ -321,8 +321,16 @@ export class SigningArchwayClient extends SigningCosmWasmClient implements IArch
       }
     });
     const response = await this.assertSignAndBroadcast(senderAddress, [message], fee, memo);
-    const rewardsAttr = logs.findAttribute(response.parsedLogs, 'archway.rewards.v1.RewardsWithdrawEvent', 'rewards');
-    const rewards = JSON.parse(rewardsAttr.value) as Coin[];
+
+    let rewards: Coin[];
+
+    try {
+      const rewardsAttr = logs.findAttribute(response.parsedLogs, 'archway.rewards.v1.RewardsWithdrawEvent', 'rewards');
+      rewards = JSON.parse(rewardsAttr.value) as Coin[];
+    } catch {
+      rewards = [];
+    }
+
     return {
       ...buildResult(response),
       rewardsAddress,

--- a/packages/arch3-core/src/signingarchwayclient.ts
+++ b/packages/arch3-core/src/signingarchwayclient.ts
@@ -327,8 +327,11 @@ export class SigningArchwayClient extends SigningCosmWasmClient implements IArch
     try {
       const rewardsAttr = logs.findAttribute(response.parsedLogs, 'archway.rewards.v1.RewardsWithdrawEvent', 'rewards');
       rewards = JSON.parse(rewardsAttr.value) as Coin[];
-    } catch {
-      rewards = [];
+    } catch (error) {
+      if ((error as Error)?.message?.includes("Could not find attribute 'rewards' in first event of type 'archway.rewards.v1.RewardsWithdrawEvent' in first log")) {
+        rewards = [];
+      }
+      else { throw error; }
     }
 
     return {


### PR DESCRIPTION
The following error was triggered on arch3.js when trying to withdraw rewards from a contract address with no outstanding rewards:

<img width="908" alt="Screenshot 2023-06-16 at 3 34 00 PM" src="https://github.com/archway-network/arch3.js/assets/8867389/2cf1489d-78f3-4548-afc1-5f12e7fb8fc5">

Now instead of throwing an error, we return an empty rewards array.

Also added a unit test to cover this scenario
