### PR TITLE
feat(core): add support for HttpBatchClient

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### New feature
+
+#### **arch3-core**
+
+- added support to create an `ArchwayClient` using an `HttpBatchClient` (#96)
+
 ### Changes
 
 #### **arch3-core**

--- a/packages/arch3-core/src/archwayclient.spec.ts
+++ b/packages/arch3-core/src/archwayclient.spec.ts
@@ -28,6 +28,14 @@ describe('ArchwayClient', () => {
     });
   });
 
+  describe('connectWithBatchClient', () => {
+    it('can be constructed', async () => {
+      const client = await ArchwayClient.connectWithBatchClient(archwayd.endpoint);
+      expect(client).toBeDefined();
+      client.disconnect();
+    });
+  });
+
   describe('rewards', () => {
     it('gets the block rewards tracking', async () => {
       const client = await ArchwayClient.connect(archwayd.endpoint);

--- a/packages/arch3-core/src/archwayclient.ts
+++ b/packages/arch3-core/src/archwayclient.ts
@@ -1,5 +1,12 @@
 import { CosmWasmClient } from '@cosmjs/cosmwasm-stargate';
-import { Tendermint34Client, TendermintClient, HttpEndpoint } from '@cosmjs/tendermint-rpc';
+import {
+  Tendermint34Client,
+  TendermintClient,
+  HttpEndpoint,
+  RpcClient,
+  HttpBatchClient,
+  HttpBatchClientOptions
+} from '@cosmjs/tendermint-rpc';
 
 import { IArchwayQueryClient, createArchwayQueryClient } from './queryclient';
 import {
@@ -33,6 +40,24 @@ export class ArchwayClient extends CosmWasmClient implements IArchwayQueryClient
    */
   public static override async connect(endpoint: string | HttpEndpoint): Promise<ArchwayClient> {
     const tmClient = await Tendermint34Client.connect(endpoint);
+    return ArchwayClient.create(tmClient);
+  }
+
+  /**
+   * Creates an instance by connecting to the given Tendermint RPC endpoint using an {@link HttpBatchClient} to batch
+   * multiple requests and increase the app performance.
+   *
+   * @param endpoint - String URL of the RPC endpoint to connect or an {@link HttpEndpoint} object.
+   * @param options - Optional configuration to control how the {@link HttpBatchClient} will batch requests.
+   * @returns An {@link ArchwayClient} connected to the endpoint.
+   *
+   * @remarks This factory method doesn't support WebSocket endpoints.
+   *
+   * @see Use {@link ArchwayClient.create} if you need Tendermint 0.37 support.
+   */
+  public static async connectWithBatchClient(endpoint: string | HttpEndpoint, options?: Partial<HttpBatchClientOptions>): Promise<ArchwayClient> {
+    const rpcClient: RpcClient = new HttpBatchClient(endpoint, options);
+    const tmClient = await Tendermint34Client.create(rpcClient);
     return ArchwayClient.create(tmClient);
   }
 

--- a/typedoc.base.json
+++ b/typedoc.base.json
@@ -7,7 +7,7 @@
     "protected": true,
     "private": false,
     "inherited": true,
-    "external": true,
+    "external": true
   },
   "validation": {
     "notExported": true,
@@ -42,7 +42,9 @@
       "TendermintClient": "https://cosmos.github.io/cosmjs/latest/tendermint-rpc/interfaces/TendermintClient.html",
       "Tendermint34Client": "https://cosmos.github.io/cosmjs/latest/tendermint-rpc/classes/tendermint34.Tendermint34Client.html",
       "Tendermint37Client": "https://cosmos.github.io/cosmjs/latest/tendermint-rpc/classes/tendermint37.Tendermint37Client.html",
-      "HttpEndpoint": "https://cosmos.github.io/cosmjs/latest/tendermint-rpc/interfaces/HttpEndpoint.html"
+      "HttpEndpoint": "https://cosmos.github.io/cosmjs/latest/tendermint-rpc/interfaces/HttpEndpoint.html",
+      "HttpBatchClient": "https://cosmos.github.io/cosmjs/latest/tendermint-rpc/classes/HttpBatchClient.html",
+      "HttpBatchClientOptions": "https://cosmos.github.io/cosmjs/latest/tendermint-rpc/interfaces/HttpBatchClientOptions.html"
     },
     "@cosmjs/proto-signing": {
       "EncodeObject": "https://cosmos.github.io/cosmjs/latest/proto-signing/interfaces/EncodeObject.html",
@@ -51,7 +53,7 @@
       "Registry": "https://cosmos.github.io/cosmjs/latest/proto-signing/interfaces/Registry.html"
     },
     "@cosmjs/amino": {
-      "Coin": "https://cosmos.github.io/cosmjs/latest/amino/interfaces/Coin.html",
+      "Coin": "https://cosmos.github.io/cosmjs/latest/amino/interfaces/Coin.html"
     }
   }
 }


### PR DESCRIPTION
This change introduces a new factory method on the `ArchwayClient` that uses an `HttpBatchClient` for batching multiple requests, reducing round-trips to the RPC endpoint.

More details on how the batch client works can be found [in the original issue](https://github.com/cosmos/cosmjs/issues/1298) or [in this usage tutorial](https://vimeo.com/771505975).