### PR TITLE
feat(core): extend SigningArchwayClient with batch client

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 #### **arch3-core**
 
+- added support to create an `SigningArchwayClient` using an
+  `HttpBatchClient` (#97)
 - added support to create an `ArchwayClient` using an `HttpBatchClient` (#96)
 
 ### Changes
@@ -40,7 +42,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 #### **arch3-core**
 
-- method to `calculateFees` for multiple messages on `SigningArchwayClient` (#86)
+- method to `calculateFees` for multiple messages on
+  `SigningArchwayClient` (#86)
 
 ### Changes
 

--- a/packages/arch3-core/src/archwayclient.ts
+++ b/packages/arch3-core/src/archwayclient.ts
@@ -45,7 +45,7 @@ export class ArchwayClient extends CosmWasmClient implements IArchwayQueryClient
 
   /**
    * Creates an instance by connecting to the given Tendermint RPC endpoint using an {@link HttpBatchClient} to batch
-   * multiple requests and increase the app performance.
+   * multiple requests and reduce queries to the server.
    *
    * @param endpoint - String URL of the RPC endpoint to connect or an {@link HttpEndpoint} object.
    * @param options - Optional configuration to control how the {@link HttpBatchClient} will batch requests.

--- a/packages/arch3-core/src/signingarchwayclient.spec.ts
+++ b/packages/arch3-core/src/signingarchwayclient.spec.ts
@@ -67,6 +67,15 @@ describe('SigningArchwayClient', () => {
     });
   });
 
+  describe('connectWithSignerAndBatchClient', () => {
+    it('can be constructed', async () => {
+      const wallet = await DirectSecp256k1HdWallet.generate(12, { prefix: archwayd.prefix });
+      const client = await SigningArchwayClient.connectWithSignerAndBatchClient(archwayd.endpoint, wallet, clientOptions);
+      expect(client).toBeDefined();
+      client.disconnect();
+    });
+  });
+
   describe('offline', () => {
     it('can be constructed', async () => {
       const wallet = await DirectSecp256k1HdWallet.generate(12, { prefix: archwayd.prefix });

--- a/packages/arch3-core/src/signingarchwayclient.ts
+++ b/packages/arch3-core/src/signingarchwayclient.ts
@@ -18,7 +18,13 @@ import {
   logs,
   StdFee
 } from '@cosmjs/stargate';
-import { Tendermint34Client, TendermintClient } from '@cosmjs/tendermint-rpc';
+import {
+  HttpBatchClient,
+  HttpBatchClientOptions,
+  RpcClient,
+  Tendermint34Client,
+  TendermintClient
+} from '@cosmjs/tendermint-rpc';
 import _ from 'lodash';
 import Long from 'long';
 
@@ -158,6 +164,31 @@ export class SigningArchwayClient extends SigningCosmWasmClient implements IArch
     options: SigningArchwayClientOptions = {},
   ): Promise<SigningArchwayClient> {
     const tmClient = await Tendermint34Client.connect(endpoint);
+    return SigningArchwayClient.createWithSigner(tmClient, signer, options);
+  }
+
+  /**
+   * Creates an instance by connecting to the given Tendermint RPC endpoint using an {@link HttpBatchClient} to batch
+   * multiple requests and reduce queries to the server.
+   *
+   * @param endpoint - String URL of the RPC endpoint to connect or an {@link HttpEndpoint} object.
+   * @param signer - The transaction signer configuration.
+   * @param options - Options for the signing client.
+   * @param batchClientOptions - Optional configuration to control how the {@link HttpBatchClient} will batch requests.
+   * @returns A {@link SigningArchwayClient} connected to the endpoint.
+   *
+   * @remarks This factory method doesn't support WebSocket endpoints.
+   *
+   * @see {@link SigningArchwayClient.createWithSigner} if you need Tendermint 0.37 support.
+   */
+  public static async connectWithSignerAndBatchClient(
+    endpoint: string | HttpEndpoint,
+    signer: OfflineSigner,
+    options?: SigningArchwayClientOptions,
+    batchClientOptions?: Partial<HttpBatchClientOptions>
+  ): Promise<SigningArchwayClient> {
+    const rpcClient: RpcClient = new HttpBatchClient(endpoint, batchClientOptions);
+    const tmClient = await Tendermint34Client.create(rpcClient);
     return SigningArchwayClient.createWithSigner(tmClient, signer, options);
   }
 


### PR DESCRIPTION
Follow up to #96, adding the same factory method to the `SigningArchwayClient`.