### PR TITLE
fix(core): workaround for batching issue in V9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## v0.7.2 (Unreleased)
+
+### Fixed
+
+#### **arch3-core**
+
+- make `connectToRpcClient` use 0.37.x version of Tendermint for both 0.37.x and 0.38.x
+RPC Clients as a workaround for a bug in batching requests in Archway V9 ([#121])
+
 ## v0.7.1 (2024-07-08)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 #### **arch3-core**
 
-- make `connectToRpcClient` use 0.37.x version of Tendermint for both 0.37.x and 0.38.x
-RPC Clients as a workaround for a bug in batching requests in Archway V9 ([#121])
+- make `connectToRpcClient` use 0.37.x version of Tendermint for both 0.37.x
+and 0.38.x RPC Clients as a workaround for a bug in batching requests in
+Archway V9 ([#121])
 
 ## v0.7.1 (2024-07-08)
 

--- a/packages/arch3-core/src/utils.ts
+++ b/packages/arch3-core/src/utils.ts
@@ -10,15 +10,17 @@ export async function connectToRpcClient(rpcClient: RpcClient): Promise<CometCli
   const tendermint37Client = await Tendermint37Client.create(rpcClient);
   const version = (await tendermint37Client.status()).nodeInfo.version;
 
-  if (version.startsWith('0.37.')) {
+  // HACK: Force Tendermint37Client on 0.38.x versions, remove when client batching issue is fixed
+  if (version.startsWith('0.37.') || version.startsWith('0.38.')) {
     return tendermint37Client;
   }
 
   tendermint37Client.disconnect();
 
-  if (version.startsWith('0.38.')) {
-    return await Comet38Client.create(rpcClient);
-  }
+  // if (version.startsWith('0.38.')) {
+  //   console.log('VERRRRR2222',version)
+  //   return await Comet38Client.create(rpcClient);
+  // }
 
   return await Tendermint34Client.create(rpcClient);
 }


### PR DESCRIPTION
There is an issue with the batch queries in Constantine (which is running protocol v9)

As a temporary workaround until finding the root cause of this issue, we can force the ArchwayClient to connect using Tendermint37Client